### PR TITLE
Add more useful gists

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,29 @@ A comprehensive collection of useful GitHub Gists organized by categories to ser
 
 | Resource | Description | Author |
 |----------|-------------|--------|
+| [ANSI Escape Codes](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797) | Reference for terminal text formatting using ANSI codes | @fnky |
 | [Common Terminal Commands](https://gist.github.com/bradtraversy/cc180de0edee05075a6139e42d5f28ce) | Essential terminal commands every developer should know | @bradtraversy |
-| [Keyboard-only Mac Cheatsheet](https://gist.github.com/lornajane/3892c39098cf70baa9c7a1874cddf233) | Complete guide for navigating Mac using only keyboard shortcuts | @lornajane |
-| [Ffmpeg usages](https://gist.github.com/protrolium/e0dbd4bb0f1a396fcb55) | Comprehensive FFmpeg command examples for video/audio processing | @protrolium |
 | [Complete list of github markdown emoji markup](https://gist.github.com/rxaviers/7360908) | All GitHub markdown emoji codes in one place | @rxaviers |
+| [Ffmpeg usages](https://gist.github.com/protrolium/e0dbd4bb0f1a396fcb55) | Comprehensive FFmpeg command examples for video/audio processing | @protrolium |
+| [Keyboard-only Mac Cheatsheet](https://gist.github.com/lornajane/3892c39098cf70baa9c7a1874cddf233) | Complete guide for navigating Mac using only keyboard shortcuts | @lornajane |
+| [List of Apple's mobile device codes](https://gist.github.com/adamawolf/3048717) | Mapping of iOS device identifiers to product names | @adamawolf |
+| [마크다운(Markdown) 사용법](https://gist.github.com/ihoneymon/652be052a0727ad59601) | Guide to Markdown syntax in Korean | @ihoneymon |
+| [Oh my ZSH with zsh-autosuggestions zsh-syntax-highlighting zsh-fast-syntax-highlighting and zsh-autocomplete.md](https://gist.github.com/n1snt/454b879b8f0b7995740ae04c5fb5b7df) | Setup for advanced ZSH features | @n1snt |
+| [set -e, -u, -o, -x pipefail explanation](https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425) | Explanation of useful bash flags for scripting | @mohanpedala |
 
 ## 🗃️ Version Control (Git)
 
 | Resource | Description | Author |
 |----------|-------------|--------|
-| [Git cheatsheet](https://gist.github.com/leocomelli/2545add34e4fec21ec16) | Quick reference for Git commands | @leocomelli |
 | [Conventional Commit messages](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) | Guide to writing consistent and meaningful commit messages | @qoomon |
+| [Git cheatsheet](https://gist.github.com/leocomelli/2545add34e4fec21ec16) | Quick reference for Git commands | @leocomelli |
 | [Git commit template](https://gist.github.com/lisawolderiksen/a7b99d94c92c6671181611be1641c733) | Template for structuring Git commit messages | @lisawolderiksen |
-| [Methods of Signing Git Commits on MacOS](https://gist.github.com/troyfontaine/18c9146295168ee9ca2b30c00bd1b41e) | Complete guide to GPG signing commits on Mac | @troyfontaine |
 | [Git Commit Freeze Due to GPG Lock Issues](https://gist.github.com/bahadiraraz/f2fb15b07e0fce92d8d5a86ab33469f7) | Solution for GPG-related Git commit problems | @bahadiraraz |
+| [GitHub Standard Fork & Pull Request Workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962) | Recommended workflow for contributing on GitHub | @Chaser324 |
+| [Methods of Signing Git Commits on MacOS](https://gist.github.com/troyfontaine/18c9146295168ee9ca2b30c00bd1b41e) | Complete guide to GPG signing commits on Mac | @troyfontaine |
+| [Semantic Commit Messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) | How to craft descriptive commit messages | @joshbuchea |
+| [Some common .gitignore configurations](https://gist.github.com/octocat/9257657) | Useful .gitignore templates for various projects | @octocat |
+| [Using multiple github accounts with ssh keys](https://gist.github.com/oanhnn/80a89405ab9023894df7) | Manage multiple GitHub accounts via SSH | @oanhnn |
 
 ## 💾 Databases
 
@@ -64,15 +73,17 @@ A comprehensive collection of useful GitHub Gists organized by categories to ser
 
 | Resource | Description | Author |
 |----------|-------------|--------|
-| [Latency Numbers Every Programmer Should Know](https://gist.github.com/jboner/2841832) | Essential latency numbers for system design | @jboner |
-| [Kafka crash course](https://gist.github.com/piyushgarg-dev/32cadf6420c452b66a9a6d977ade0b01) | Quick introduction to Apache Kafka | @piyushgarg-dev |
-| [Programming as Theory Building](https://gist.github.com/onlurking/fc5c81d18cfce9ff81bc968a7f342fb1) | Classic essay on programming philosophy | @onlurking |
 | [Falsehood programmers believe about time](https://gist.github.com/timvisee/fcda9bbdff88d45cc9061606b4b923ca) | Common misconceptions about time in programming | @timvisee |
+| [Kafka crash course](https://gist.github.com/piyushgarg-dev/32cadf6420c452b66a9a6d977ade0b01) | Quick introduction to Apache Kafka | @piyushgarg-dev |
+| [Latency Numbers Every Programmer Should Know](https://gist.github.com/jboner/2841832) | Essential latency numbers for system design | @jboner |
+| [Programming as Theory Building](https://gist.github.com/onlurking/fc5c81d18cfce9ff81bc968a7f342fb1) | Classic essay on programming philosophy | @onlurking |
+| [System Design Cheatsheet](https://gist.github.com/vasanthk/485d1c25737e8e72759f) | Quick reference for designing scalable systems | @vasanthk |
 
 ## 🔒 Security & Reverse Engineering
 
 | Resource | Description | Author |
 |----------|-------------|--------|
+| [Google dork cheatsheet](https://gist.github.com/sundowndev/283efaddbcf896ab405488330d1bbc06) | Advanced search queries for security research | @sundowndev |
 | [Pwntools Cheatsheet](https://gist.github.com/anvbis/64907e4f90974c4bdd930baeb705dedf) | Quick reference for pwntools CTF framework | @anvbis |
 | [Reverse Engineering / Deobfuscating Web App Code](https://gist.github.com/0xdevalias/d8b743efb82c0e9406fc69da0d6c6581) | Tools and techniques for analyzing obfuscated JavaScript | @0xdevalias |
 
@@ -81,12 +92,15 @@ A comprehensive collection of useful GitHub Gists organized by categories to ser
 | Resource | Description | Author |
 |----------|-------------|--------|
 | [Cluely System Prompt](https://gist.github.com/cablej/ccfe7fe097d8bbb05519bacfeb910038) | System prompt examples and best practices | @cablej |
+| [Manus tools and prompts](https://gist.github.com/jlia0/db0a9695b3ca7609c9b1a08dcbf872c9) | Collection of Manus-related AI prompts | @jlia0 |
+| [Normcore LLM Reads](https://gist.github.com/veekaybee/be375ab33085102f9027853128dc5f0e) | Recommended readings on language models | @veekaybee |
 
 ## 🎨 Frontend & Design
 
 | Resource | Description | Author |
 |----------|-------------|--------|
 | [Hexadecimal color code for transparency](https://gist.github.com/lopspower/03fb1cc0ac9f32ef38f4) | Alpha transparency values in hex format | @lopspower |
+| [What forces layout/reflow. The comprehensive list.](https://gist.github.com/paulirish/5d52fb081b3570c81e3a) | Guide to browser rendering triggers | @paulirish |
 
 ## 📚 Learning Resources
 
@@ -98,6 +112,7 @@ A comprehensive collection of useful GitHub Gists organized by categories to ser
 
 | Resource | Description | Author |
 |----------|-------------|--------|
+| [国内的 Docker Hub 镜像加速器](https://gist.github.com/y0ngb1n/7e8f16af3242c7815e7ca2f0833d3ea6) | List of mainland China Docker Hub mirror services | @y0ngb1n |
 
 ## 💡 Project Ideas
 


### PR DESCRIPTION
## Summary
- add additional development tool gists (ANSI codes, markdown guide, zsh extras and more)
- expand Git section with semantic commit guides and gitignore tips
- include system design cheatsheet and Docker mirror resources
- list helpful AI prompt collections and security references
- add browser reflow guide under frontend resources

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d3467134c832daabdd08bf10f14fc